### PR TITLE
TrueTypeFontFamilyName bug fix

### DIFF
--- a/netDxf/Tables/TextStyle.cs
+++ b/netDxf/Tables/TextStyle.cs
@@ -376,9 +376,16 @@ namespace netDxf.Tables
                 if (!File.Exists(fontFile)) return string.Empty;
             }
 
-            PrivateFontCollection fontCollection = new PrivateFontCollection();
-            fontCollection.AddFontFile(fontFile);
-            return fontCollection.Families[0].Name;
+            try
+            {
+                PrivateFontCollection fontCollection = new PrivateFontCollection();
+                fontCollection.AddFontFile(fontFile);
+                return fontCollection.Families[0].Name;
+            }
+            catch (FileNotFoundException)
+            {
+                return string.Empty;
+            }
         }
 
         #endregion


### PR DESCRIPTION

The AddFontFile method creates a FileNotFoundException exception not only in cases where it does not find the file. He can also create it if the specified font is not supported. What does the https://docs.microsoft.com/en-us/dotnet/api/system.drawing.text.privatefontcollection.addfontfile?view=netframework-4.7.2